### PR TITLE
Update to docling 0.2.0

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/docling/deployment/DoclingProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/docling/deployment/DoclingProcessor.java
@@ -5,7 +5,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.jandex.ClassType;
 import org.jboss.jandex.DotName;
 
-import ai.docling.api.serve.DoclingServeApi;
+import ai.docling.serve.api.DoclingServeApi;
 import io.quarkiverse.docling.runtime.DoclingRecorder;
 import io.quarkiverse.docling.runtime.client.DoclingService;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;

--- a/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiAvailableTests.java
+++ b/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiAvailableTests.java
@@ -15,8 +15,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import ai.docling.api.serve.DoclingServeApi;
-import ai.docling.api.serve.health.HealthCheckResponse;
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.health.HealthCheckResponse;
 import io.quarkiverse.docling.runtime.config.DoclingRuntimeConfig;
 import io.quarkus.test.QuarkusUnitTest;
 

--- a/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiLogRequestsResponsesTests.java
+++ b/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiLogRequestsResponsesTests.java
@@ -16,8 +16,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import ai.docling.api.serve.DoclingServeApi;
-import ai.docling.api.serve.health.HealthCheckResponse;
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.health.HealthCheckResponse;
 import io.quarkiverse.docling.runtime.config.DoclingRuntimeConfig;
 import io.quarkus.test.QuarkusUnitTest;
 

--- a/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiLogRequestsTests.java
+++ b/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiLogRequestsTests.java
@@ -14,8 +14,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import ai.docling.api.serve.DoclingServeApi;
-import ai.docling.api.serve.health.HealthCheckResponse;
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.health.HealthCheckResponse;
 import io.quarkiverse.docling.runtime.config.DoclingRuntimeConfig;
 import io.quarkus.test.QuarkusUnitTest;
 

--- a/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiLogResponsesTests.java
+++ b/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiLogResponsesTests.java
@@ -13,8 +13,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import ai.docling.api.serve.DoclingServeApi;
-import ai.docling.api.serve.health.HealthCheckResponse;
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.health.HealthCheckResponse;
 import io.quarkiverse.docling.runtime.config.DoclingRuntimeConfig;
 import io.quarkus.test.QuarkusUnitTest;
 

--- a/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingDevServiceWorksTests.java
+++ b/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingDevServiceWorksTests.java
@@ -9,8 +9,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import ai.docling.api.serve.DoclingServeApi;
-import ai.docling.api.serve.health.HealthCheckResponse;
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.health.HealthCheckResponse;
 import io.quarkus.test.QuarkusUnitTest;
 
 class DoclingDevServiceWorksTests {

--- a/docs/modules/ROOT/pages/includes/quarkus-docling.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-docling.adoc
@@ -26,7 +26,7 @@ Environment variable: `+++QUARKUS_DOCLING_DEVSERVICES_IMAGE+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++ghcr.io/docling-project/docling-serve:v1.8.0+++`
+|`+++ghcr.io/docling-project/docling-serve:v1.9.0+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-docling_quarkus-docling-devservices-enable-ui]] [.property-path]##link:#quarkus-docling_quarkus-docling-devservices-enable-ui[`quarkus.docling.devservices.enable-ui`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-docling_quarkus.docling.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-docling_quarkus.docling.adoc
@@ -26,7 +26,7 @@ Environment variable: `+++QUARKUS_DOCLING_DEVSERVICES_IMAGE+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++ghcr.io/docling-project/docling-serve:v1.8.0+++`
+|`+++ghcr.io/docling-project/docling-serve:v1.9.0+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-docling_quarkus-docling-devservices-enable-ui]] [.property-path]##link:#quarkus-docling_quarkus-docling-devservices-enable-ui[`quarkus.docling.devservices.enable-ui`]##
 ifdef::add-copy-button-to-config-props[]

--- a/integration-tests/src/test/java/io/quarkiverse/docling/tests/DoclingTests.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docling/tests/DoclingTests.java
@@ -14,8 +14,8 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import ai.docling.api.serve.convert.request.options.OutputFormat;
-import ai.docling.api.serve.convert.response.ConvertDocumentResponse;
+import ai.docling.serve.api.convert.request.options.OutputFormat;
+import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
 import io.quarkiverse.docling.runtime.client.DoclingService;
 import io.quarkus.test.junit.QuarkusTest;
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <assertj.version>3.27.6</assertj.version>
     <compiler-plugin.version>3.14.1</compiler-plugin.version>
-	  <docling-java.version>0.1.5</docling-java.version>
+	  <docling-java.version>0.2.0</docling-java.version>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/runtime/src/main/java/io/quarkiverse/docling/runtime/DoclingRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/docling/runtime/DoclingRecorder.java
@@ -3,7 +3,7 @@ package io.quarkiverse.docling.runtime;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import ai.docling.api.serve.DoclingServeApi;
+import ai.docling.serve.api.DoclingServeApi;
 import io.quarkiverse.docling.runtime.client.DoclingClientBuilder;
 import io.quarkiverse.docling.runtime.client.DoclingService;
 import io.quarkiverse.docling.runtime.config.DoclingRuntimeConfig;

--- a/runtime/src/main/java/io/quarkiverse/docling/runtime/client/DoclingClientBuilder.java
+++ b/runtime/src/main/java/io/quarkiverse/docling/runtime/client/DoclingClientBuilder.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jboss.resteasy.reactive.client.api.LoggingScope;
 
-import ai.docling.api.serve.DoclingServeApi;
+import ai.docling.serve.api.DoclingServeApi;
 import io.quarkiverse.docling.runtime.config.DoclingRuntimeConfig;
 import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 

--- a/runtime/src/main/java/io/quarkiverse/docling/runtime/client/QuarkusDoclingServeClient.java
+++ b/runtime/src/main/java/io/quarkiverse/docling/runtime/client/QuarkusDoclingServeClient.java
@@ -7,10 +7,13 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import ai.docling.api.serve.DoclingServeApi;
-import ai.docling.api.serve.convert.request.ConvertDocumentRequest;
-import ai.docling.api.serve.convert.response.ConvertDocumentResponse;
-import ai.docling.api.serve.health.HealthCheckResponse;
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.chunk.request.HierarchicalChunkDocumentRequest;
+import ai.docling.serve.api.chunk.request.HybridChunkDocumentRequest;
+import ai.docling.serve.api.chunk.response.ChunkDocumentResponse;
+import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
+import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
+import ai.docling.serve.api.health.HealthCheckResponse;
 
 /**
  * A Quarkus REST Client interface for interacting with the Docling Serve API.
@@ -34,6 +37,20 @@ public interface QuarkusDoclingServeClient extends DoclingServeApi {
     @Consumes(MediaType.APPLICATION_JSON)
     @POST
     ConvertDocumentResponse convertSource(ConvertDocumentRequest request);
+
+    @Override
+    @Path("/v1/chunk/hierarchical/source")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @POST
+    ChunkDocumentResponse chunkSourceWithHierarchicalChunker(HierarchicalChunkDocumentRequest request);
+
+    @Override
+    @Path("/v1/chunk/hybrid/source")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @POST
+    ChunkDocumentResponse chunkSourceWithHybridChunker(HybridChunkDocumentRequest request);
 
     @Override
     default <T extends DoclingServeApi, B extends DoclingApiBuilder<T, B>> DoclingApiBuilder<T, B> toBuilder() {


### PR DESCRIPTION
Align `docling-serve` API package structure, upgrade `docling-java` to v0.2.0, and update `docling-serve` image version to v1.9.0. Add support for hierarchical and hybrid document chunking APIs.