### PR TITLE
Upgrade `docling-java` to v0.4.1

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/docling/tests/DoclingServeApiTests.java
+++ b/integration-tests/src/test/java/io/quarkiverse/docling/tests/DoclingServeApiTests.java
@@ -40,6 +40,10 @@ import ai.docling.serve.api.convert.request.source.HttpSource;
 import ai.docling.serve.api.convert.response.ConvertDocumentResponse;
 import ai.docling.serve.api.health.HealthCheckResponse;
 import ai.docling.serve.api.task.request.TaskStatusPollRequest;
+import ai.docling.serve.api.validation.ValidationError;
+import ai.docling.serve.api.validation.ValidationErrorContext;
+import ai.docling.serve.api.validation.ValidationErrorDetail;
+import ai.docling.serve.api.validation.ValidationException;
 
 @QuarkusTest
 class DoclingServeApiTests {
@@ -78,10 +82,7 @@ class DoclingServeApiTests {
                     .build();
 
             assertThatThrownBy(() -> doclingServeApi.pollTaskStatus(request))
-                    .hasRootCauseInstanceOf(WebApplicationException.class)
-                    .rootCause()
                     .asInstanceOf(InstanceOfAssertFactories.throwable(WebApplicationException.class))
-                    .hasMessage("Not Found, status code 404")
                     .extracting(ex -> ex.getResponse().getStatus())
                     .isEqualTo(404);
         }
@@ -113,6 +114,50 @@ class DoclingServeApiTests {
             }
 
             assertThat(response.getDocument().getMarkdownContent()).isNotEmpty();
+        }
+
+        @Test
+        void shouldThrowValidationError() {
+            var file = Path.of("src", "test", "resources", "story.pdf");
+
+            assertThat(file)
+                    .exists()
+                    .isRegularFile();
+
+            var source = HttpSource.builder()
+                    .url(file.toUri())
+                    .build();
+
+            var options = ConvertDocumentOptions.builder()
+                    .toFormat(OutputFormat.MARKDOWN)
+                    .build();
+
+            var request = ConvertDocumentRequest.builder()
+                    .source(source)
+                    .options(options)
+                    .build();
+
+            assertThatThrownBy(() -> doclingServeApi.convertSource(request))
+                    .isInstanceOf(ValidationException.class)
+                    .hasMessageStartingWith("An error occurred while making request to ")
+                    .asInstanceOf(InstanceOfAssertFactories.throwable(ValidationException.class))
+                    .extracting(ValidationException::getValidationError)
+                    .isNotNull()
+                    .extracting(ValidationError::getErrorDetails)
+                    .asInstanceOf(InstanceOfAssertFactories.list(ValidationErrorDetail.class))
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(
+                            ValidationErrorDetail.builder()
+                                    .type("url_scheme")
+                                    .message("URL scheme should be 'http' or 'https'")
+                                    .locations(List.of("body", "sources", 0, "http", "url"))
+                                    .input(file.toUri().toString())
+                                    .context(
+                                            ValidationErrorContext.builder()
+                                                    .expectedSchemes("'http' or 'https'")
+                                                    .build())
+                                    .build());
         }
 
         @Test
@@ -716,6 +761,94 @@ class DoclingServeApiTests {
 
             List<Chunk> chunks = response.getChunks();
             assertThat(chunks).allMatch(chunk -> !chunk.getText().isEmpty());
+        }
+
+        @Test
+        void shouldThrowValidationErrorHierarchicalChunker() {
+            var file = Path.of("src", "test", "resources", "story.pdf");
+
+            assertThat(file)
+                    .exists()
+                    .isRegularFile();
+
+            var source = HttpSource.builder()
+                    .url(file.toUri())
+                    .build();
+
+            var options = ConvertDocumentOptions.builder()
+                    .toFormat(OutputFormat.MARKDOWN)
+                    .build();
+
+            var request = HierarchicalChunkDocumentRequest.builder()
+                    .source(source)
+                    .options(options)
+                    .build();
+
+            assertThatThrownBy(() -> doclingServeApi.chunkSourceWithHierarchicalChunker(request))
+                    .isInstanceOf(ValidationException.class)
+                    .hasMessageStartingWith("An error occurred while making request to ")
+                    .asInstanceOf(InstanceOfAssertFactories.throwable(ValidationException.class))
+                    .extracting(ValidationException::getValidationError)
+                    .isNotNull()
+                    .extracting(ValidationError::getErrorDetails)
+                    .asInstanceOf(InstanceOfAssertFactories.list(ValidationErrorDetail.class))
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(
+                            ValidationErrorDetail.builder()
+                                    .type("url_scheme")
+                                    .message("URL scheme should be 'http' or 'https'")
+                                    .locations(List.of("body", "sources", 0, "http", "url"))
+                                    .input(file.toUri().toString())
+                                    .context(
+                                            ValidationErrorContext.builder()
+                                                    .expectedSchemes("'http' or 'https'")
+                                                    .build())
+                                    .build());
+        }
+
+        @Test
+        void shouldThrowValidationErrorHybridChunker() {
+            var file = Path.of("src", "test", "resources", "story.pdf");
+
+            assertThat(file)
+                    .exists()
+                    .isRegularFile();
+
+            var source = HttpSource.builder()
+                    .url(file.toUri())
+                    .build();
+
+            var options = ConvertDocumentOptions.builder()
+                    .toFormat(OutputFormat.MARKDOWN)
+                    .build();
+
+            var request = HybridChunkDocumentRequest.builder()
+                    .source(source)
+                    .options(options)
+                    .build();
+
+            assertThatThrownBy(() -> doclingServeApi.chunkSourceWithHybridChunker(request))
+                    .isInstanceOf(ValidationException.class)
+                    .hasMessageStartingWith("An error occurred while making request to ")
+                    .asInstanceOf(InstanceOfAssertFactories.throwable(ValidationException.class))
+                    .extracting(ValidationException::getValidationError)
+                    .isNotNull()
+                    .extracting(ValidationError::getErrorDetails)
+                    .asInstanceOf(InstanceOfAssertFactories.list(ValidationErrorDetail.class))
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .isEqualTo(
+                            ValidationErrorDetail.builder()
+                                    .type("url_scheme")
+                                    .message("URL scheme should be 'http' or 'https'")
+                                    .locations(List.of("body", "sources", 0, "http", "url"))
+                                    .input(file.toUri().toString())
+                                    .context(
+                                            ValidationErrorContext.builder()
+                                                    .expectedSchemes("'http' or 'https'")
+                                                    .build())
+                                    .build());
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <assertj.version>3.27.6</assertj.version>
     <compiler-plugin.version>3.14.1</compiler-plugin.version>
-	  <docling-java.version>0.4.0</docling-java.version>
+	  <docling-java.version>0.4.1</docling-java.version>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
- add validation error handling for `convertSource`, `hierarchicalChunker`, and `hybridChunker`.

Fixes #80