### PR TITLE
Fix empty keyword entry in quarkus-extension.yaml

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -4,7 +4,6 @@ description: Runs Docling as an API service. Docling simplifies document process
 metadata:
   keywords:
     - ai
-    -
     - docling
   guide: "https://docs.quarkiverse.io/quarkus-docling/dev/index.html"
   icon-url: "https://raw.githubusercontent.com/docling-project/docling-java/refs/heads/main/docs/src/doc/docs/assets/img/docling-java.png"


### PR DESCRIPTION
Removed an empty keyword entry in the quarkus-extension.yaml file.  This causes all extensions to not render.