### PR TITLE
feat: upgrade to docling-java 0.6.0, add PresignedUrlTarget and batch conversion support

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -49,7 +49,6 @@
 		<dependency>
 			<groupId>ai.docling</groupId>
 			<artifactId>docling-testcontainers</artifactId>
-			<version>${docling-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>

--- a/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiBatchConvertTests.java
+++ b/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiBatchConvertTests.java
@@ -1,0 +1,103 @@
+package io.quarkiverse.docling.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.convert.request.BatchConvertDocumentRequest;
+import ai.docling.serve.api.convert.request.CallbackSpec;
+import ai.docling.serve.api.convert.request.source.HttpSource;
+import ai.docling.serve.api.convert.request.target.PresignedUrlTarget;
+import ai.docling.serve.api.task.response.TaskStatus;
+import io.quarkiverse.docling.runtime.config.DoclingRuntimeConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+class DoclingApiBatchConvertTests extends RequestResponseLoggingTests {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.docling.devservices.enabled", "false")
+            .overrideRuntimeConfigKey(DoclingRuntimeConfig.BASE_URL_KEY, wiremockUrlForConfig());
+
+    @Inject
+    DoclingServeApi doclingApi;
+
+    @Test
+    void shouldConvertSourceBatch() {
+        wiremock().register(
+                post(urlPathEqualTo("/v1/convert/source/batch"))
+                        .withHeader(HttpHeaders.CONTENT_TYPE, containing(MediaType.APPLICATION_JSON))
+                        .willReturn(okJson("""
+                                {
+                                  "task_id": "batch-task-123",
+                                  "task_type": "convert",
+                                  "task_status": "pending",
+                                  "task_position": 1,
+                                  "task_meta": null
+                                }
+                                """)));
+
+        var request = BatchConvertDocumentRequest.builder()
+                .source(HttpSource.builder()
+                        .url(URI.create("https://arxiv.org/pdf/2408.09869"))
+                        .build())
+                .source(HttpSource.builder()
+                        .url(URI.create("https://arxiv.org/pdf/2501.17887"))
+                        .build())
+                .target(PresignedUrlTarget.builder().build())
+                .build();
+
+        var response = doclingApi.convertSourceBatch(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getTaskId()).isEqualTo("batch-task-123");
+        assertThat(response.getTaskStatus()).isEqualTo(TaskStatus.PENDING);
+    }
+
+    @Test
+    void shouldConvertSourceBatchWithCallbacks() {
+        wiremock().register(
+                post(urlPathEqualTo("/v1/convert/source/batch"))
+                        .withHeader(HttpHeaders.CONTENT_TYPE, containing(MediaType.APPLICATION_JSON))
+                        .willReturn(okJson("""
+                                {
+                                  "task_id": "batch-callback-789",
+                                  "task_type": "convert",
+                                  "task_status": "pending",
+                                  "task_position": 1,
+                                  "task_meta": null
+                                }
+                                """)));
+
+        var request = BatchConvertDocumentRequest.builder()
+                .source(HttpSource.builder()
+                        .url(URI.create("https://arxiv.org/pdf/2408.09869"))
+                        .build())
+                .target(PresignedUrlTarget.builder().build())
+                .callback(CallbackSpec.builder()
+                        .url(URI.create("https://my-app.example.com/docling/progress"))
+                        .header("Authorization", "Bearer token123")
+                        .build())
+                .build();
+
+        var response = doclingApi.convertSourceBatch(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getTaskId()).isEqualTo("batch-callback-789");
+        assertThat(response.getTaskStatus()).isEqualTo(TaskStatus.PENDING);
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiPresignedUrlTargetTests.java
+++ b/deployment/src/test/java/io/quarkiverse/docling/deployment/DoclingApiPresignedUrlTargetTests.java
@@ -1,0 +1,183 @@
+package io.quarkiverse.docling.deployment;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import ai.docling.serve.api.DoclingServeApi;
+import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
+import ai.docling.serve.api.convert.request.source.HttpSource;
+import ai.docling.serve.api.convert.request.target.PresignedUrlTarget;
+import ai.docling.serve.api.convert.response.ArtifactType;
+import ai.docling.serve.api.convert.response.ConversionStatus;
+import ai.docling.serve.api.convert.response.PreSignedUrlConvertResponse;
+import ai.docling.serve.api.convert.response.ResponseType;
+import io.quarkiverse.docling.runtime.config.DoclingRuntimeConfig;
+import io.quarkus.test.QuarkusUnitTest;
+
+class DoclingApiPresignedUrlTargetTests extends RequestResponseLoggingTests {
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class))
+            .overrideConfigKey("quarkus.docling.devservices.enabled", "false")
+            .overrideRuntimeConfigKey(DoclingRuntimeConfig.BASE_URL_KEY, wiremockUrlForConfig());
+
+    @Inject
+    DoclingServeApi doclingApi;
+
+    @Test
+    void shouldConvertWithPresignedUrlTarget() {
+        wiremock().register(
+                post(urlPathEqualTo("/v1/convert/source"))
+                        .withHeader(HttpHeaders.CONTENT_TYPE, containing(MediaType.APPLICATION_JSON))
+                        .willReturn(okJson("""
+                                {
+                                  "processing_time": 4.13,
+                                  "num_converted": 1,
+                                  "num_succeeded": 1,
+                                  "num_partially_succeeded": 0,
+                                  "num_failed": 0,
+                                  "documents": [
+                                    {
+                                      "source_index": 0,
+                                      "source_uri": "https://arxiv.org/pdf/2408.09869",
+                                      "filename": "2408.09869",
+                                      "status": "success",
+                                      "errors": [],
+                                      "timings": {},
+                                      "artifacts": [
+                                        {
+                                          "artifact_type": "markdown",
+                                          "mime_type": "text/markdown",
+                                          "uri": "https://storage.example.com/2408.09869.md",
+                                          "url_expires_at": "2026-06-15T12:00:00Z"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """)));
+
+        var request = ConvertDocumentRequest.builder()
+                .source(HttpSource.builder()
+                        .url(URI.create("https://arxiv.org/pdf/2408.09869"))
+                        .build())
+                .target(PresignedUrlTarget.builder().build())
+                .build();
+
+        var response = doclingApi.convertSource(request);
+
+        assertThat(response)
+                .isNotNull()
+                .isInstanceOf(PreSignedUrlConvertResponse.class);
+
+        assertThat(response.getResponseType())
+                .isEqualTo(ResponseType.PRE_SIGNED_URL_RESPONSE);
+
+        var presignedResponse = (PreSignedUrlConvertResponse) response;
+        assertThat(presignedResponse.getProcessingTime()).isEqualTo(4.13);
+        assertThat(presignedResponse.getNumConverted()).isEqualTo(1);
+        assertThat(presignedResponse.getNumSucceeded()).isEqualTo(1);
+        assertThat(presignedResponse.getNumPartiallySucceeded()).isZero();
+        assertThat(presignedResponse.getNumFailed()).isZero();
+
+        assertThat(presignedResponse.getDocuments()).hasSize(1);
+        var doc = presignedResponse.getDocuments().get(0);
+        assertThat(doc.getSourceIndex()).isZero();
+        assertThat(doc.getSourceUri()).isEqualTo("https://arxiv.org/pdf/2408.09869");
+        assertThat(doc.getFilename()).isEqualTo("2408.09869");
+        assertThat(doc.getStatus()).isEqualTo(ConversionStatus.SUCCESS);
+        assertThat(doc.getErrors()).isEmpty();
+        assertThat(doc.getArtifacts()).hasSize(1);
+
+        var artifact = doc.getArtifacts().get(0);
+        assertThat(artifact.getArtifactType()).isEqualTo(ArtifactType.MARKDOWN);
+        assertThat(artifact.getMimeType()).isEqualTo("text/markdown");
+        assertThat(artifact.getUri()).isEqualTo(URI.create("https://storage.example.com/2408.09869.md"));
+        assertThat(artifact.getUrlExpiresAt()).isNotNull();
+    }
+
+    @Test
+    void shouldConvertMultipleSourcesWithPresignedUrlTarget() {
+        wiremock().register(
+                post(urlPathEqualTo("/v1/convert/source"))
+                        .withHeader(HttpHeaders.CONTENT_TYPE, containing(MediaType.APPLICATION_JSON))
+                        .willReturn(okJson("""
+                                {
+                                  "processing_time": 8.27,
+                                  "num_converted": 2,
+                                  "num_succeeded": 2,
+                                  "num_partially_succeeded": 0,
+                                  "num_failed": 0,
+                                  "documents": [
+                                    {
+                                      "source_index": 0,
+                                      "source_uri": "https://arxiv.org/pdf/2408.09869",
+                                      "filename": "2408.09869",
+                                      "status": "success",
+                                      "artifacts": [
+                                        {
+                                          "artifact_type": "markdown",
+                                          "mime_type": "text/markdown",
+                                          "uri": "https://storage.example.com/2408.09869.md"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "source_index": 1,
+                                      "source_uri": "https://arxiv.org/pdf/2501.17887",
+                                      "filename": "2501.17887",
+                                      "status": "success",
+                                      "artifacts": [
+                                        {
+                                          "artifact_type": "markdown",
+                                          "mime_type": "text/markdown",
+                                          "uri": "https://storage.example.com/2501.17887.md"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """)));
+
+        var request = ConvertDocumentRequest.builder()
+                .source(HttpSource.builder()
+                        .url(URI.create("https://arxiv.org/pdf/2408.09869"))
+                        .build())
+                .source(HttpSource.builder()
+                        .url(URI.create("https://arxiv.org/pdf/2501.17887"))
+                        .build())
+                .target(PresignedUrlTarget.builder().build())
+                .build();
+
+        var response = doclingApi.convertSource(request);
+
+        assertThat(response)
+                .isNotNull()
+                .isInstanceOf(PreSignedUrlConvertResponse.class);
+
+        assertThat(response.getResponseType())
+                .isEqualTo(ResponseType.PRE_SIGNED_URL_RESPONSE);
+
+        var presignedResponse = (PreSignedUrlConvertResponse) response;
+        assertThat(presignedResponse.getNumConverted()).isEqualTo(2);
+        assertThat(presignedResponse.getNumSucceeded()).isEqualTo(2);
+        assertThat(presignedResponse.getDocuments()).hasSize(2);
+        assertThat(presignedResponse.getDocuments().get(0).getFilename()).isEqualTo("2408.09869");
+        assertThat(presignedResponse.getDocuments().get(1).getFilename()).isEqualTo("2501.17887");
+        assertThat(presignedResponse.getDocuments().get(1).getSourceIndex()).isEqualTo(1);
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-docling.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-docling.adoc
@@ -49,7 +49,7 @@ Environment variable: `+++QUARKUS_DOCLING_DEVSERVICES_IMAGE+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++ghcr.io/docling-project/docling-serve:v1.19.0+++`
+|`+++ghcr.io/docling-project/docling-serve:v1.24.0+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-docling_quarkus-docling-devservices-enable-ui]] [.property-path]##link:#quarkus-docling_quarkus-docling-devservices-enable-ui[`+++quarkus.docling.devservices.enable-ui+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-docling_quarkus.docling.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-docling_quarkus.docling.adoc
@@ -49,7 +49,7 @@ Environment variable: `+++QUARKUS_DOCLING_DEVSERVICES_IMAGE+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`+++ghcr.io/docling-project/docling-serve:v1.19.0+++`
+|`+++ghcr.io/docling-project/docling-serve:v1.24.0+++`
 
 a|icon:lock[title=Fixed at build time] [[quarkus-docling_quarkus-docling-devservices-enable-ui]] [.property-path]##link:#quarkus-docling_quarkus-docling-devservices-enable-ui[`+++quarkus.docling.devservices.enable-ui+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse</groupId>
     <artifactId>quarkiverse-parent</artifactId>
-    <version>21</version>
+    <version>22</version>
   </parent>
   <groupId>io.quarkiverse.docling</groupId>
   <artifactId>quarkus-docling-parent</artifactId>
@@ -34,7 +34,7 @@
   <properties>
     <assertj.version>3.27.7</assertj.version>
     <compiler-plugin.version>3.15.0</compiler-plugin.version>
-	  <docling-java.version>0.5.3</docling-java.version>
+	  <docling-java.version>0.6.0</docling-java.version>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -68,6 +68,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+	    <dependency>
+		    <groupId>ai.docling</groupId>
+		    <artifactId>docling-bom</artifactId>
+		    <version>${docling-java.version}</version>
+		    <type>pom</type>
+		    <scope>import</scope>
+	    </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -24,7 +24,6 @@
 		<dependency>
 			<groupId>ai.docling</groupId>
 			<artifactId>docling-serve-api</artifactId>
-			<version>${docling-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>

--- a/runtime/src/main/java/io/quarkiverse/docling/runtime/client/QuarkusDoclingServeApi.java
+++ b/runtime/src/main/java/io/quarkiverse/docling/runtime/client/QuarkusDoclingServeApi.java
@@ -17,7 +17,9 @@ import ai.docling.serve.api.chunk.response.ChunkDocumentResponse;
 import ai.docling.serve.api.clear.request.ClearConvertersRequest;
 import ai.docling.serve.api.clear.request.ClearResultsRequest;
 import ai.docling.serve.api.clear.response.ClearResponse;
+import ai.docling.serve.api.convert.request.BatchConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
+import ai.docling.serve.api.convert.request.target.PresignedUrlTarget;
 import ai.docling.serve.api.convert.request.target.PutTarget;
 import ai.docling.serve.api.convert.request.target.S3Target;
 import ai.docling.serve.api.convert.request.target.ZipTarget;
@@ -104,7 +106,8 @@ public class QuarkusDoclingServeApi implements DoclingServeApi {
     @Override
     public ConvertDocumentResponse convertSource(ConvertDocumentRequest request) {
         var hasMultipleSources = !Utils.isNullOrEmpty(request.getSources()) ? request.getSources().size() > 1 : Boolean.FALSE;
-        var isRemoteTarget = (request.getTarget() instanceof S3Target) || (request.getTarget() instanceof PutTarget);
+        var isRemoteTarget = (request.getTarget() instanceof S3Target) || (request.getTarget() instanceof PutTarget)
+                || (request.getTarget() instanceof PresignedUrlTarget);
         var isZipTarget = request.getTarget() instanceof ZipTarget;
 
         var response = this.client.convertSource(request, this.apiMetadata);
@@ -117,6 +120,17 @@ public class QuarkusDoclingServeApi implements DoclingServeApi {
     @Override
     public CompletionStage<ConvertDocumentResponse> convertSourceAsync(ConvertDocumentRequest request) {
         return executeAsync(() -> this.client.submitConvertSourceAsync(request, this.apiMetadata), TaskResultType.CONVERT);
+    }
+
+    @Override
+    public TaskStatusPollResponse convertSourceBatch(BatchConvertDocumentRequest request) {
+        return this.client.convertSourceBatch(request, this.apiMetadata);
+    }
+
+    @Override
+    public CompletionStage<ConvertDocumentResponse> convertSourceBatchAsync(BatchConvertDocumentRequest request) {
+        return executeAsync(() -> this.client.submitConvertSourceBatchAsync(request, this.apiMetadata),
+                TaskResultType.CONVERT);
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/docling/runtime/client/QuarkusDoclingServeConvertApi.java
+++ b/runtime/src/main/java/io/quarkiverse/docling/runtime/client/QuarkusDoclingServeConvertApi.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import ai.docling.serve.api.convert.request.BatchConvertDocumentRequest;
 import ai.docling.serve.api.convert.request.ConvertDocumentRequest;
 import ai.docling.serve.api.task.response.TaskStatusPollResponse;
 import io.smallrye.mutiny.Uni;
@@ -24,4 +25,17 @@ public interface QuarkusDoclingServeConvertApi {
     @Consumes(MediaType.APPLICATION_JSON)
     @POST
     Uni<TaskStatusPollResponse> submitConvertSourceAsync(ConvertDocumentRequest request, @BeanParam ApiMetadata metadata);
+
+    @Path("/v1/convert/source/batch")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @POST
+    TaskStatusPollResponse convertSourceBatch(BatchConvertDocumentRequest request, @BeanParam ApiMetadata metadata);
+
+    @Path("/v1/convert/source/batch")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @POST
+    Uni<TaskStatusPollResponse> submitConvertSourceBatchAsync(BatchConvertDocumentRequest request,
+            @BeanParam ApiMetadata metadata);
 }


### PR DESCRIPTION
## Summary

- Upgrade docling-java from 0.5.3 to 0.6.0 and import docling-bom for centralized dependency management
- Add `PresignedUrlTarget` to the `isRemoteTarget` check in `convertSource()` so multi-source presigned URL requests are not incorrectly treated as ZIP responses
- Implement `convertSourceBatch()` and `convertSourceBatchAsync()` for the new `/v1/convert/source/batch` endpoint
- Add `Uni`-returning `submitConvertSourceBatchAsync()` to `QuarkusDoclingServeConvertApi` REST client, following the existing async pattern
- Add WireMock-based deployment tests for both presigned URL target (single + multi-source) and batch conversion (basic + with callbacks)

## Test plan

- [x] `./mvnw clean compile -DskipTests` — no compilation errors
- [x] `./mvnw verify -pl deployment` — all 11 deployment tests pass (4 new)
- [x] `./mvnw clean verify` — full build including integration tests with updated container image (v1.24.0)

Closes #131
Closes #132