### PR TITLE
Bump docling-java from 0.6.1 to 0.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <assertj.version>3.27.7</assertj.version>
     <compiler-plugin.version>3.16.0</compiler-plugin.version>
-	  <docling-java.version>0.6.1</docling-java.version>
+	  <docling-java.version>0.6.5</docling-java.version>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## What

Bumps the `docling-java` dependency (imported via `ai.docling:docling-bom`) from **0.6.1** to **0.6.5**.

## Why

docling-java `0.6.4` refactored the Serve API request types to Lombok `@SuperBuilder`, which moved the `source`/`sources`/`clearSources`/`target` builder mutators up to the abstract `DocumentRequest.Builder`. The concrete builders only inherited them. Fluent calls such as `ConvertDocumentRequest.builder().source(...)` therefore had their `invokevirtual` owner as the concrete subtype, which the JVM resolves fine but GraalVM `--link-at-build-time` (enabled globally by Quarkus) reports as unresolved — breaking the native image build.

`0.6.5` ships the upstream fix (docling-project/docling-java PR #666): covariant mutator overrides are declared directly on each concrete request builder, so the calls resolve at native build time. No extension source changes are required.

## Verification

- `./mvnw -B clean verify` — SUCCESS (JVM tests)
- `./mvnw -B clean verify -Dnative` — `DoclingServeIT` passes 8/8